### PR TITLE
Add a blog section hosted on jupyter.org with client-side search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 .jekyll-metadata
 vendor
 .bundle
+__pycache__

--- a/_config.yml
+++ b/_config.yml
@@ -19,3 +19,10 @@ include: [".well-known"]
 
 plugins:
   - jekyll-redirect-from
+  - jekyll-feed
+
+# Blog settings
+permalink: /blog/:year/:month/:day/:title/
+feed:
+  path: blog/feed.xml
+  posts_limit: 20

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -11,5 +11,4 @@ head:
     - JupyterHub
     - Widgets
     - title: Blog
-      url: https://blog.jupyter.org
-      newpage: true
+      url: /blog/

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,6 +18,8 @@
     <link rel="stylesheet" href="{{ "/css/github-buttons.css" | prepend: site.baseurl }}">
     <link rel="stylesheet" href="{{ "/css/markdown_page.css" | prepend: site.baseurl }}">
     <link rel="stylesheet" href="{{ "/css/about.css" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ "/css/blog.css" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ "/css/syntax.css" | prepend: site.baseurl }}">
     <link rel="icon" type="image/png" href="favicon.ico" />
     <link href="{{site.baseurl}}/assets/apple-touch-icon.png" rel="apple-touch-icon" />
     <link href="{{site.baseurl}}/assets/apple-touch-icon-76x76.png" rel="apple-touch-icon" sizes="76x76" />

--- a/_layouts/blog_post.html
+++ b/_layouts/blog_post.html
@@ -1,0 +1,36 @@
+---
+layout: default
+---
+<div class="post">
+  <header class="post-header header header-grey blog-post-header">
+    <h1 class="blog-post-title">{{ page.title }}</h1>
+    <p class="blog-post-meta">
+      {{ page.date | date: "%B %-d, %Y" }}{% if page.author %} &bull; {{ page.author }}{% endif %}
+    </p>
+    {% if page.tags and page.tags != empty %}
+    <p class="blog-post-tags">
+      {% for tag in page.tags %}<span class="blog-tag">{{ tag }}</span>{% endfor %}
+    </p>
+    {% endif %}
+  </header>
+
+  <article class="post-content">
+    <div class="section-white top-section-border">
+      <div class="blog-post-content container">
+        {{ content }}
+
+        {% if page.original_url %}
+        <hr class="blog-post-divider" />
+        <p class="blog-post-origin">
+          This post was originally published on the
+          <a href="{{ page.original_url }}">Jupyter Blog on Medium</a>.
+        </p>
+        {% endif %}
+
+        <p class="blog-post-backlink">
+          <a href="{{ site.baseurl }}/blog/">&larr; Back to the blog</a>
+        </p>
+      </div>
+    </div>
+  </article>
+</div>

--- a/_posts/2025-11-24-jupyterlab-4-5-and-notebook-7-5-are-available.md
+++ b/_posts/2025-11-24-jupyterlab-4-5-and-notebook-7-5-are-available.md
@@ -1,0 +1,70 @@
+---
+layout: blog_post
+title: "JupyterLab 4.5 and Notebook 7.5 are available!"
+author: Jeremy Tuloup
+date: 2025-11-24
+tags: [jupyterlab, notebook, release]
+original_url: https://blog.jupyter.org/jupyterlab-4-5-and-notebook-7-5-are-available-1bcd1fa19a47
+---
+
+JupyterLab 4.5 and Jupyter Notebook 7.5 have been released! This new minor
+release of JupyterLab includes 51 new features and enhancements, 81 bug fixes,
+44 maintenance tasks and 38 documentation improvements. Jupyter Notebook 7.5
+has also been released, including many of the fixes and enhancements from the
+JupyterLab 4.5 release.
+
+## Highlights
+
+### Audio and video viewers
+
+JupyterLab now includes built-in audio and video viewers, so you can open
+audio and video files directly from the file browser without leaving
+JupyterLab.
+
+### Automatic theme switching
+
+JupyterLab can now automatically switch between light and dark themes when
+"Synchronize with System Settings" is enabled, following your operating
+system's appearance preference.
+
+### Better cell rendering by default
+
+The default windowing mode is now `contentVisibility`, which improves cell
+rendering performance and alleviates a number of previously reported issues
+with the full windowing mode.
+
+### Accessibility improvements
+
+This release continues the ongoing accessibility work in JupyterLab:
+
+- Dialog components display buttons and checkboxes on separate lines for
+  better readability.
+- Selections in the terminal have better visibility under high-contrast
+  themes.
+- Keyboard navigation and the tab order in the status bar have been improved.
+
+## Try it now
+
+You can try JupyterLab 4.5 by installing it from PyPI:
+
+```bash
+pip install --upgrade jupyterlab
+```
+
+Or with conda / mamba:
+
+```bash
+conda install -c conda-forge jupyterlab
+```
+
+Similarly, for Jupyter Notebook:
+
+```bash
+pip install --upgrade notebook
+```
+
+## Acknowledgements
+
+Many thanks to the 50+ contributors who made this release possible, and to
+all the users who reported issues and tested pre-releases. See the JupyterLab
+changelog for the full list of changes and contributors.

--- a/_posts/2026-02-19-jupyterlite-officially-joins-project-jupyter.md
+++ b/_posts/2026-02-19-jupyterlite-officially-joins-project-jupyter.md
@@ -1,0 +1,54 @@
+---
+layout: blog_post
+title: "JupyterLite Officially Joins Project Jupyter!"
+author: Project Jupyter
+date: 2026-02-19
+tags: [jupyterlite, webassembly, announcement]
+original_url: https://blog.jupyter.org/jupyterlite-officially-joins-project-jupyter-77df24c8db80
+---
+
+JupyterLite is now an official part of Project Jupyter! This milestone marks
+a significant step forward for interactive computing in the browser and
+strengthens JupyterLite's role within the Jupyter ecosystem.
+
+## What is JupyterLite?
+
+JupyterLite is a JupyterLab distribution that runs entirely in your web
+browser. Kernels execute directly in the browser using WebAssembly, which
+eliminates the need for an application server. A JupyterLite site is just a
+collection of static files, so it can be deployed anywhere static files can
+be hosted.
+
+## Why it matters
+
+Running Jupyter entirely in the browser has some compelling benefits:
+
+- **Instant access**: start computing with a single click — no prior Python
+  setup, environment configuration, or server management required.
+- **Scalability**: host thousands of concurrent users from a static website
+  (for example GitHub Pages) with zero per-user server costs.
+- **Privacy and portability**: code and data remain in the user's browser,
+  which makes JupyterLite ideal for embedding in documentation, tutorials,
+  and interactive demos.
+
+JupyterLite already powers the "Try Jupyter" experience on the official
+Jupyter website, and it is used by projects such as numpy.org and sympy.org
+for interactive documentation. It also underlies services such as Jupyter
+Everywhere and notebook.link.
+
+## Joining the Jupyter Frontends subproject
+
+JupyterLite becomes part of the Jupyter Frontends subproject, alongside
+JupyterLab and Jupyter Notebook. Bringing JupyterLite into the Frontends
+subproject offers several benefits, including much easier coordination with
+JupyterLab and Notebook development — many technical decisions in JupyterLab
+affect JupyterLite, and vice versa.
+
+Since its creation in 2021, JupyterLite has grown from an experimental proof
+of concept into a widely used distribution with a rich ecosystem of kernels
+and extensions, including the Pyodide-based Python kernel and the xeus
+family of WebAssembly kernels.
+
+We are excited about this next chapter for interactive computing in the
+browser. Try it out, report issues, and contribute — JupyterLite development
+happens in the open, and new contributors are always welcome!

--- a/_posts/2026-03-13-700-jupyterlab-4-extensions.md
+++ b/_posts/2026-03-13-700-jupyterlab-4-extensions.md
@@ -1,0 +1,53 @@
+---
+layout: blog_post
+title: "700 JupyterLab 4 Extensions!"
+author: Konstantin Taletskiy
+date: 2026-03-13
+tags: [jupyterlab, extensions, community]
+original_url: https://blog.jupyter.org/700-jupyterlab-4-extensions-8ac295b3d974
+---
+
+The JupyterLab extension ecosystem just crossed 700 extensions compatible
+with JupyterLab 4! These are 700 community-built plugins created by hundreds
+of developers, research labs, and companies around the world.
+
+## A growing ecosystem
+
+The ecosystem crossed 600 JupyterLab 4 compatible extensions in late October
+2025, just days before JupyterCon in San Diego, and hit 700 by early March
+2026. Growth has been remarkably steady, averaging about 18 new extensions
+per month — with November 2025 setting an all-time monthly record of 33 new
+extensions.
+
+Modern tooling is helping: better templates, documentation, and code
+generation tools have lowered the bar for extension development, which once
+required deep familiarity with TypeScript, Lumino, and JupyterLab internals.
+
+## What people are building
+
+Looking at the ecosystem by category:
+
+- **Development & Version Control** dominates both in count (267 extensions)
+  and downloads (5.4 million per month).
+- **Visualization & Dashboards** is the second most downloaded category at
+  2.7 million downloads per month.
+- **System & Resource Management** rounds out the top three at 602 thousand
+  downloads per month.
+
+## AI tooling: a signal for 2026
+
+AI is not yet the biggest category in JupyterLab, but it may be the clearest
+signal of where new interaction patterns are emerging:
+
+- `jupyter-ai-acp-client` brings external AI agents into JupyterLab's chat
+  via the Agent Communication Protocol, and ships with Claude Code and Kiro
+  personas.
+- `nb-margin` lets you annotate cells with margin comments that an AI coding
+  agent can read and edit — a different paradigm from chat-based AI
+  assistance.
+
+## Thank you
+
+This milestone belongs to the whole community: everyone who built,
+maintained, documented, and packaged an extension over the years. Here's to
+the next hundred!

--- a/_posts/2026-04-08-bids-joins-the-mybinder-federation.md
+++ b/_posts/2026-04-08-bids-joins-the-mybinder-federation.md
@@ -1,0 +1,39 @@
+---
+layout: blog_post
+title: "Berkeley Institute for Data Science (BIDS) joins the mybinder.org federation in partnership with 2i2c"
+author: Yuvi Panda
+date: 2026-04-08
+tags: [binder, mybinder, community]
+original_url: https://blog.jupyter.org/berkeley-institute-for-data-science-bids-joins-the-mybinder-org-federation-with-help-from-2i2c-f0f22d0b5ba5
+---
+
+The Berkeley Institute for Data Science (BIDS) is now a part of the
+mybinder.org federation!
+
+BIDS is the birthplace of the current iteration of mybinder.org, all the way
+back in 2017. In 2026, they are back as a member of the federation, joining
+2i2c and GESIS in contributing to the cloud costs of keeping mybinder.org
+running for everyone, for free.
+
+## How the node came up
+
+This node was brought up in partnership with 2i2c, which contributed
+expertise in extending the mybinder.org deployment infrastructure to run on
+OVH, as well as working with UC Berkeley procurement to ensure that the
+cloud costs can be paid for on a continuous basis.
+
+## Why cloud provider diversity matters
+
+The BIDS node runs on the OVH cloud provider, joining the two existing nodes
+(from 2i2c and GESIS) that run on Hetzner. By running on a different cloud
+provider than our existing nodes, we reduce the risk that a single cloud
+provider outage — or policy change — will take down the entire mybinder.org
+service.
+
+## Join the federation
+
+mybinder.org is operated as a federation: independent organizations run
+BinderHub deployments that together serve the community's traffic. If your
+organization would like to support reproducible, sharable interactive
+computing by joining the federation, please reach out — we would love to
+talk to you.

--- a/_posts/2026-04-20-exploring-petabytes-of-the-night-sky.md
+++ b/_posts/2026-04-20-exploring-petabytes-of-the-night-sky.md
@@ -1,0 +1,46 @@
+---
+layout: blog_post
+title: "Exploring Petabytes of the Night Sky — Jupyter Notebooks at NOIRLab's Astro Data Lab Science Platform"
+author: Robert Nikutta
+date: 2026-04-20
+tags: [science, astronomy, jupyterhub, guest-post]
+original_url: https://blog.jupyter.org/exploring-petabytes-of-the-night-sky-jupyter-notebooks-at-noirlabs-astro-data-lab-science-ae012dfd4723
+---
+
+What if you could query 420+ billion rows of astronomical catalog data from
+a Jupyter notebook in your browser, in seconds? That is what the Astro Data
+Lab science platform at NSF NOIRLab's Community Science and Data Center
+makes possible — and since its public launch in June 2017 it has become one
+of the largest deployments of Jupyter notebooks in professional science.
+
+## The data
+
+Astro Data Lab contains about 420 billion catalog rows across 30+ major
+astronomical surveys — DES, the Legacy Surveys, DESI, the NOIRLab Source
+Catalog, SDSS, Gaia, unWISE, SMASH, S-PLUS, VHS, 2MASS, and dozens more —
+plus 31 million spectra served via SPARCL (the SPectra Analysis and
+Retrievable Catalog Lab), and petabytes of images accessible through a
+Simple Image Access service and a cutout API.
+
+## Jupyter as the front door
+
+Every registered user gets a persistent JupyterHub environment with the full
+astronomy Python stack pre-loaded — Astropy, NumPy, SciPy, Matplotlib,
+Pandas, scikit-learn — along with the `astro-datalab` client library for
+querying the databases and retrieving spectra and images. Because the
+notebooks run next to the data, users can crossmatch enormous catalogs and
+work with survey-scale datasets without ever downloading them.
+
+A curated collection of example notebooks helps newcomers get started, from
+introductory how-tos to complete published science cases that can be
+reproduced end-to-end in the browser.
+
+## The community
+
+Today more than 4,800 astronomers in over 90 countries use Astro Data Lab,
+submitting tens of millions of data queries each year — from students
+writing their first query to research teams preparing large survey papers.
+
+Jupyter notebooks have become the lingua franca of data-intensive astronomy,
+and platforms like Astro Data Lab show what is possible when open-source
+scientific computing infrastructure meets open data.

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,53 @@
+---
+layout: default
+title: Blog
+permalink: /blog/
+---
+<div class="post">
+  <header class="post-header header header-grey blog-index-header">
+    <h1 class="blog-post-title">Jupyter Blog</h1>
+    <p class="blog-index-tagline">News and updates from the Jupyter community</p>
+    <div class="blog-search">
+      <label for="blog-search-input" class="sr-only">Search blog posts</label>
+      <input type="search" id="blog-search-input" class="blog-search-input"
+             placeholder="Search blog posts&hellip;" autocomplete="off" />
+      <p id="blog-search-status" class="blog-search-status" aria-live="polite"></p>
+    </div>
+  </header>
+
+  <article class="post-content">
+    <div class="section-white top-section-border">
+      <div class="blog-post-content container">
+        <div id="blog-post-list" class="blog-post-list"
+             data-search-index="{{ site.baseurl }}/blog/search.json">
+          {% for post in site.posts %}
+          <article class="blog-list-item" data-url="{{ post.url | prepend: site.baseurl }}">
+            <h2 class="blog-list-title">
+              <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+            </h2>
+            <p class="blog-list-meta">
+              {{ post.date | date: "%B %-d, %Y" }}{% if post.author %} &bull; {{ post.author }}{% endif %}
+            </p>
+            <p class="blog-list-excerpt">{{ post.excerpt | strip_html | normalize_whitespace | truncate: 280 }}</p>
+            {% if post.tags and post.tags != empty %}
+            <p class="blog-post-tags">
+              {% for tag in post.tags %}<span class="blog-tag">{{ tag }}</span>{% endfor %}
+            </p>
+            {% endif %}
+          </article>
+          {% endfor %}
+        </div>
+        <p id="blog-no-results" class="blog-no-results" hidden>
+          No posts match your search.
+        </p>
+        <hr class="blog-post-divider" />
+        <p class="blog-index-footer">
+          Subscribe via <a href="{{ site.baseurl }}/blog/feed.xml">RSS</a>.
+          Older posts are available on the
+          <a href="https://blog.jupyter.org">Jupyter Blog on Medium</a>.
+        </p>
+      </div>
+    </div>
+  </article>
+</div>
+<script src="{{ site.baseurl }}/js/blog-search.js" defer></script>

--- a/blog/search.json
+++ b/blog/search.json
@@ -1,0 +1,15 @@
+---
+layout: null
+---
+[
+{% for post in site.posts %}
+  {
+    "title": {{ post.title | jsonify }},
+    "author": {{ post.author | default: "" | jsonify }},
+    "date": {{ post.date | date: "%B %-d, %Y" | jsonify }},
+    "url": {{ post.url | prepend: site.baseurl | jsonify }},
+    "tags": {{ post.tags | join: " " | jsonify }},
+    "content": {{ post.content | strip_html | normalize_whitespace | jsonify }}
+  }{% unless forloop.last %},{% endunless %}
+{% endfor %}
+]

--- a/css/blog.css
+++ b/css/blog.css
@@ -1,0 +1,146 @@
+/* Styles for the blog section (blog index and blog posts). */
+
+.blog-post-header h1.blog-post-title,
+.blog-index-header h1.blog-post-title {
+  margin: 0 auto;
+  padding: 0 30px;
+  max-width: 920px;
+}
+
+.blog-post-meta,
+.blog-index-tagline {
+  color: #757575;
+  margin-top: 12px;
+}
+
+/* Override the generic `.header p { margin: 0 30% }` rule so long
+   metadata lines wrap nicely on small screens. */
+.header p.blog-post-meta,
+.header p.blog-index-tagline,
+.header p.blog-post-tags,
+.header p.blog-search-status {
+  margin: 8px auto 0 auto;
+  max-width: 720px;
+  padding: 0 30px;
+}
+
+.blog-post-tags {
+  margin-top: 12px;
+}
+
+.blog-tag {
+  display: inline-block;
+  background-color: #eeeeee;
+  border: 1px solid #e0e0e0;
+  border-radius: 3px;
+  color: #616161;
+  font-size: 13px;
+  margin: 2px 4px 2px 0;
+  padding: 2px 8px;
+}
+
+/* Search box in the blog index header */
+.blog-search {
+  margin: 24px auto 0 auto;
+  max-width: 560px;
+  padding: 0 30px;
+}
+
+.blog-search-input {
+  width: 100%;
+  font-size: 16px;
+  padding: 10px 14px;
+  border: 1px solid #bdbdbd;
+  border-radius: 4px;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.blog-search-input:focus {
+  outline: none;
+  border-color: #f37626; /* Jupyter orange */
+}
+
+.blog-search-status {
+  color: #757575;
+  font-size: 14px;
+  min-height: 1em;
+}
+
+/* Post list on the blog index */
+.blog-post-content {
+  padding: 0 30px;
+  margin: 0 auto;
+  max-width: 860px;
+}
+
+.blog-list-item {
+  border-bottom: 1px solid #e0e0e0;
+  padding: 24px 0;
+}
+
+.blog-list-item:last-child {
+  border-bottom: none;
+}
+
+.blog-list-item[hidden] {
+  display: none;
+}
+
+.blog-list-title {
+  margin: 0 0 4px 0;
+  font-size: 24px;
+}
+
+.blog-list-meta {
+  color: #757575;
+  font-size: 14px;
+  margin-bottom: 8px;
+}
+
+.blog-list-excerpt {
+  margin-bottom: 8px;
+}
+
+.blog-no-results {
+  color: #757575;
+  font-style: italic;
+  padding: 24px 0;
+}
+
+/* Post body typography */
+.blog-post-content h2 {
+  margin-top: 36px;
+}
+
+.blog-post-content h3 {
+  margin-top: 28px;
+}
+
+.blog-post-content img {
+  max-width: 100%;
+  height: auto;
+  margin: 16px auto;
+  display: block;
+}
+
+.blog-post-content blockquote {
+  border-left: 4px solid #f37626;
+  color: #616161;
+  font-size: inherit;
+  margin: 16px 0;
+  padding: 4px 16px;
+}
+
+.blog-post-divider {
+  margin: 40px 0 24px 0;
+}
+
+.blog-post-origin,
+.blog-index-footer {
+  color: #757575;
+  font-size: 14px;
+}
+
+.blog-post-backlink {
+  margin-top: 16px;
+}

--- a/js/blog-search.js
+++ b/js/blog-search.js
@@ -1,0 +1,91 @@
+/* Client-side search for the Jupyter blog.
+ * Filters the server-rendered post list against a JSON index of full post
+ * text (blog/search.json), so the page works without JavaScript and search
+ * works without a server. */
+(function () {
+  'use strict';
+
+  var input = document.getElementById('blog-search-input');
+  var list = document.getElementById('blog-post-list');
+  var status = document.getElementById('blog-search-status');
+  var noResults = document.getElementById('blog-no-results');
+  if (!input || !list) {
+    return;
+  }
+
+  var items = Array.prototype.slice.call(
+    list.querySelectorAll('.blog-list-item')
+  );
+  var index = null; // url -> searchable text, populated lazily
+
+  function loadIndex() {
+    if (index) {
+      return;
+    }
+    index = {};
+    var request = new XMLHttpRequest();
+    request.open('GET', list.getAttribute('data-search-index') || '/blog/search.json');
+    request.onload = function () {
+      if (request.status < 200 || request.status >= 300) {
+        return;
+      }
+      var posts;
+      try {
+        posts = JSON.parse(request.responseText);
+      } catch (e) {
+        return;
+      }
+      posts.forEach(function (post) {
+        index[post.url] = (
+          post.title + ' ' + post.author + ' ' + post.date + ' ' +
+          post.tags + ' ' + post.content
+        ).toLowerCase();
+      });
+      // Re-run the current query now that full-text data is available.
+      applyFilter(input.value);
+    };
+    request.send();
+  }
+
+  function itemText(item) {
+    var url = item.getAttribute('data-url');
+    if (index && index[url]) {
+      return index[url];
+    }
+    // Fall back to the visible text until the index has loaded.
+    return item.textContent.toLowerCase();
+  }
+
+  function applyFilter(query) {
+    var terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+    var shown = 0;
+    items.forEach(function (item) {
+      var text = itemText(item);
+      var match = terms.every(function (term) {
+        return text.indexOf(term) !== -1;
+      });
+      item.hidden = !match;
+      if (match) {
+        shown += 1;
+      }
+    });
+    if (noResults) {
+      noResults.hidden = shown !== 0;
+    }
+    if (status) {
+      if (terms.length === 0) {
+        status.textContent = '';
+      } else if (shown === 1) {
+        status.textContent = '1 matching post';
+      } else {
+        status.textContent = shown + ' matching posts';
+      }
+    }
+  }
+
+  input.addEventListener('focus', loadIndex);
+  input.addEventListener('input', function () {
+    loadIndex();
+    applyFilter(input.value);
+  });
+})();


### PR DESCRIPTION
Experiment with hosting the Jupyter blog on jupyter.org instead of Medium.

## What's included

- **`/blog/` index page** listing all posts, with a search box. Search is client-side: `blog/search.json` is a Liquid-generated full-text index of every post, and `js/blog-search.js` filters the server-rendered post list against it (title, author, tags, and body text; AND semantics across terms, live result count, no-results state). No external dependencies, works on plain GitHub Pages, and the page degrades gracefully without JavaScript to a full post listing.
- **`blog_post` layout** styled like the rest of the site (grey header, white content section), showing date/author/tags, a "back to the blog" link, and — for ported posts — a link to the original on Medium (driven by `original_url` in the front matter).
- **Five recent posts** ported into `_posts/` (JupyterLab 4.5/Notebook 7.5, JupyterLite joining Project Jupyter, 700 JupyterLab 4 extensions, BIDS joining the mybinder.org federation, and the NOIRLab Astro Data Lab guest post).
- **RSS feed** at `/blog/feed.xml` via `jekyll-feed` (already in the Gemfile via the `github-pages` gem; now enabled in `_config.yml`).
- **Navbar** Blog entry now points to `/blog/` instead of opening Medium.

Post URLs follow `/blog/:year/:month/:day/:title/`.

## ⚠️ Post content is reconstructed, not copied verbatim

The environment this branch was authored in could not reach blog.jupyter.org or medium.com, so the five posts are faithful reconstructions from search-engine results rather than verbatim copies — accurate in facts, titles, authors, and dates as far as could be verified, but not the exact original prose, and without the original images. Before publishing for real, replace the bodies of the files in `_posts/` with the original text (e.g. from a Medium export).

## Testing

- `bundle exec jekyll build` passes; verified the rendered index, post pages, `search.json` (valid JSON, all 5 posts indexed), and feed.
- Browser-tested the search with Playwright/Chromium against the built site: full-text matches (terms appearing only in post bodies), multi-term queries, no-results state, and clearing all behave correctly with no JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8VC7h5fjqGJzYo8SUfFk5